### PR TITLE
Fix docker driver MemorySwap value

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -838,7 +838,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		hostConfig.MemorySwap = 0
 		hostConfig.MemorySwappiness = nil
 	} else {
-		hostConfig.MemorySwap = task.Resources.LinuxResources.MemoryLimitBytes // MemorySwap is memory + swap.
+		hostConfig.MemorySwap = memory
 
 		// disable swap explicitly in non-Windows environments
 		var swapiness int64 = 0


### PR DESCRIPTION
Fixes an incorrect value being assigned to MemorySwap when `memory_hard_limit` flag is being used.

Issue raised in https://github.com/hashicorp/nomad/issues/8153